### PR TITLE
Normalise locale string when used by SmartlingTranslator

### DIFF
--- a/lib/Phreepio/Translator/SmartlingTranslator.php
+++ b/lib/Phreepio/Translator/SmartlingTranslator.php
@@ -21,7 +21,7 @@ class SmartlingTranslator implements Adapter
 
     public function download($remotePath, $localPath, $locale)
     {
-        $this->client->get($remotePath, $localPath, $locale);
+        $this->client->get($remotePath, $localPath, $this->normaliseLocale($locale));
     }
 
     public function upload($localPath, $remotePath, $type)
@@ -35,6 +35,17 @@ class SmartlingTranslator implements Adapter
 
     public function status($remotePath, $locale)
     {
-        return (object)$this->client->status($remotePath, $locale);
+        return (object)$this->client->status($remotePath, $this->normaliseLocale($locale));
+    }
+
+    /**
+     * Perform basic normalisation of locale string for usage by Smartling.
+     * Allow local locales to be specified as xx_yy while Smartling expects xx-yy.
+     * @param string $locale
+     * @return string
+     */
+    private function normaliseLocale($locale)
+    {
+        return str_replace('_', '-', $locale);
     }
 }


### PR DESCRIPTION
This adds basic normalisation of the locale string sent to Smartling, to allow for locally specified locales containing underscores, e.g. `xx_YY`. Smartling expects locale strings to contain dashes, e.g. `xx-YY`.

This should be a non-breaking change, existing usage of `xx-yy` locales in `phreepio.json` will continue to work.

This feels like the least-intrusive solution. Looking into adding additional formatting options along the lines of `%locale.xx_YY%` when specifying the destination location felt like it was going to be making too many assumptions about how the locale looked. For example, what if it is xx-yy-zz or some other valid format. As an aside, the RFC for language tags specifies dashes (http://www.ietf.org/rfc/rfc4646.txt), which is also what PHP itself conforms to.
