### PR TITLE
Add a caching feature for downloading translations

### DIFF
--- a/lib/Phreepio/Translator/Adapter.php
+++ b/lib/Phreepio/Translator/Adapter.php
@@ -9,4 +9,6 @@ interface Adapter
     public function upload($localPath, $remotePath, $type);
 
     public function status($remotePath, $locale);
+
+    public function enableCache();
 }

--- a/lib/Phreepio/Translator/SmartlingTranslator.php
+++ b/lib/Phreepio/Translator/SmartlingTranslator.php
@@ -9,14 +9,15 @@ class SmartlingTranslator implements Adapter
     private $client;
     private $autoApprove;
     private $placeholderFormat;
+    private $enableCache;
 
     public function __construct($config)
     {
         $useSandbox = isset($config->useSandbox) ? $config->useSandbox : true;
         $this->placeholderFormat = isset($config->placeholderFormat) ? $config->placeholderFormat : null;
-
         $this->autoApprove = isset($config->autoApprove) ? $config->autoApprove : false ;
         $this->client = new Client($config->apiKey, $config->projectId, $useSandbox);
+        $this->enableCache = isset($config->enableCache) ? $config->enableCache : false;
     }
 
     public function download($remotePath, $localPath, $locale)
@@ -36,6 +37,11 @@ class SmartlingTranslator implements Adapter
     public function status($remotePath, $locale)
     {
         return (object)$this->client->status($remotePath, $this->normaliseLocale($locale));
+    }
+
+    public function enableCache()
+    {
+        return $this->enableCache;
     }
 
     /**

--- a/lib/Phreepio/Translator/Translator.php
+++ b/lib/Phreepio/Translator/Translator.php
@@ -20,15 +20,18 @@ class Translator
 
     public function getDownloadIterator()
     {
+        $skeletonPaths = array();
         $remotePaths = array();
-        foreach ($this->config->sources as $source) {
+
+        foreach ($this->config->sources as $skeletonPath => $source) {
             $remotePaths[] = $source->target;
+            $skeletonPaths[] = $skeletonPath;
         }
 
         $locales = $this->config->target->locales;
         $destinationPattern = $this->config->target->destination;
 
-        return new DownloadIterator($this->adapter, $remotePaths, $locales, $destinationPattern);
+        return new DownloadIterator($this->adapter, $remotePaths, $skeletonPaths, $locales, $destinationPattern);
     }
 
     public function getStatusIterator()
@@ -39,6 +42,6 @@ class Translator
         }
 
         $locales = $this->config->target->locales;
-        return new StatusIterator($this->adapter, $remotePaths, $locales);        
+        return new StatusIterator($this->adapter, $remotePaths, $locales);
     }
 }


### PR DESCRIPTION
# What is this for?

Translation download can be very slow. This PR aims to cache translations that are already been downloaded for reuse if no translations has changed. 

Cached translations gets saved in a `{local-translation-path}.cache/{skeleton-filename}.{md5-hash}/` folder
To clear the translation cache just remove the `{local-translation-path}/.cache` folder.

This feature is can be opt in by setting a config "enableCache" in phreepio.json

```
{
    "translator": {
        "service": "Phreepio\\Translator\\SmartlingTranslator",
        "config": {
            ...
            "enableCache": true
            ...
        }
    },
    ...
}
```
