### PR TITLE
Make the translation download cache bustable

### DIFF
--- a/lib/Phreepio/Translator/Adapter.php
+++ b/lib/Phreepio/Translator/Adapter.php
@@ -11,4 +11,6 @@ interface Adapter
     public function status($remotePath, $locale);
 
     public function enableCache();
+
+    public function cacheVersion();
 }

--- a/lib/Phreepio/Translator/DownloadIterator.php
+++ b/lib/Phreepio/Translator/DownloadIterator.php
@@ -139,10 +139,11 @@ class DownloadIterator implements \Iterator
         $hash = md5_file($skeletonPath);
 
         return sprintf(
-            "%s/.cache/%s.%s/%s",
+            "%s/.cache/%s.%s.%s/%s",
             $pathInfo['dirname'],
             pathinfo($skeletonPath, PATHINFO_FILENAME),
             $hash,
+            $this->translator->cacheVersion(),
             $pathInfo['basename']
         );
     }

--- a/lib/Phreepio/Translator/SmartlingTranslator.php
+++ b/lib/Phreepio/Translator/SmartlingTranslator.php
@@ -10,6 +10,7 @@ class SmartlingTranslator implements Adapter
     private $autoApprove;
     private $placeholderFormat;
     private $enableCache;
+    private $cacheVersion;
 
     public function __construct($config)
     {
@@ -18,6 +19,7 @@ class SmartlingTranslator implements Adapter
         $this->autoApprove = isset($config->autoApprove) ? $config->autoApprove : false ;
         $this->client = new Client($config->apiKey, $config->projectId, $useSandbox);
         $this->enableCache = isset($config->enableCache) ? $config->enableCache : false;
+        $this->cacheVersion = isset($config->cacheVersion) ? $config->cacheVersion : "v1.0";
     }
 
     public function download($remotePath, $localPath, $locale)
@@ -42,6 +44,11 @@ class SmartlingTranslator implements Adapter
     public function enableCache()
     {
         return $this->enableCache;
+    }
+
+    public function cacheVersion()
+    {
+        return $this->cacheVersion;
     }
 
     /**


### PR DESCRIPTION
Adding a config key for busting the translation cache.

**Usage:**
Change the `cacheVersion` value to anything else will force phreepio to download new translations 

**phreepio.json**

```
{
  "translator": {
    ...
    "config": {
      "cacheVersion": "v1.0"
    }
    ...
  }
}
```
