### PR TITLE
Concurrent downloads using guzzle pools

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "lwc/phreepio",
     "type": "application",
-    "version": "1.4.0",
+    "version": "0.0.3",
     "description": "Tool to facilitate translation using 3rd party APIs",
     "keywords": ["cli", "translation", "i18n"],
     "license": "MIT",

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "lwc/phreepio",
     "type": "application",
-    "version": "0.0.3",
+    "version": "2.0.0",
     "description": "Tool to facilitate translation using 3rd party APIs",
     "keywords": ["cli", "translation", "i18n"],
     "license": "MIT",
@@ -12,8 +12,9 @@
         }
     ],
     "require": {
-        "lwc/smartling-php": ">=0.0.1",
-        "symfony/console": "~2.1"
+        "symfony/console": "~2.1",
+        "guzzlehttp/guzzle": "~5",
+        "react/promise": "~2.2"
     },
     "autoload": {
         "psr-0": { "Phreepio": "lib" }

--- a/composer.lock
+++ b/composer.lock
@@ -1,72 +1,43 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file"
+        "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "This file is @generated automatically"
     ],
-    "hash": "609f0615adc72fe0cf79905ceb3e2856",
+    "hash": "e979709a936fbfcc65ecf0606312852b",
     "packages": [
         {
-            "name": "guzzle/guzzle",
-            "version": "v3.1.2",
+            "name": "guzzlehttp/guzzle",
+            "version": "5.2.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/guzzle/guzzle",
-                "reference": "v3.1.2"
+                "url": "https://github.com/guzzle/guzzle.git",
+                "reference": "475b29ccd411f2fa8a408e64576418728c032cfa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://github.com/guzzle/guzzle/archive/v3.1.2.zip",
-                "reference": "v3.1.2",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/475b29ccd411f2fa8a408e64576418728c032cfa",
+                "reference": "475b29ccd411f2fa8a408e64576418728c032cfa",
                 "shasum": ""
             },
             "require": {
-                "ext-curl": "*",
-                "php": ">=5.3.2",
-                "symfony/event-dispatcher": ">=2.1"
-            },
-            "replace": {
-                "guzzle/batch": "self.version",
-                "guzzle/cache": "self.version",
-                "guzzle/common": "self.version",
-                "guzzle/http": "self.version",
-                "guzzle/inflection": "self.version",
-                "guzzle/iterator": "self.version",
-                "guzzle/log": "self.version",
-                "guzzle/parser": "self.version",
-                "guzzle/plugin": "self.version",
-                "guzzle/plugin-async": "self.version",
-                "guzzle/plugin-backoff": "self.version",
-                "guzzle/plugin-cache": "self.version",
-                "guzzle/plugin-cookie": "self.version",
-                "guzzle/plugin-curlauth": "self.version",
-                "guzzle/plugin-history": "self.version",
-                "guzzle/plugin-log": "self.version",
-                "guzzle/plugin-md5": "self.version",
-                "guzzle/plugin-mock": "self.version",
-                "guzzle/plugin-oauth": "self.version",
-                "guzzle/service": "self.version",
-                "guzzle/stream": "self.version"
+                "guzzlehttp/ringphp": "~1.0",
+                "php": ">=5.4.0"
             },
             "require-dev": {
-                "doctrine/common": "*",
-                "monolog/monolog": "1.*",
-                "phpunit/phpunit": "3.7.*",
-                "symfony/class-loader": "*",
-                "zend/zend-cache1": "1.12",
-                "zend/zend-log1": "1.12",
-                "zendframework/zend-cache": "2.0.*",
-                "zendframework/zend-log": "2.0.*"
+                "ext-curl": "*",
+                "phpunit/phpunit": "~4.0",
+                "psr/log": "~1.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1-dev"
+                    "dev-master": "5.0-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "Guzzle\\Tests": "tests/",
-                    "Guzzle": "src/"
+                "psr-4": {
+                    "GuzzleHttp\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -78,10 +49,6 @@
                     "name": "Michael Dowling",
                     "email": "mtdowling@gmail.com",
                     "homepage": "https://github.com/mtdowling"
-                },
-                {
-                    "name": "Guzzle Community",
-                    "homepage": "https://github.com/guzzle/guzzle/contributors"
                 }
             ],
             "description": "Guzzle is a PHP HTTP client library and framework for building RESTful web service clients",
@@ -95,29 +62,43 @@
                 "rest",
                 "web service"
             ],
-            "time": "2013-01-28 00:07:40"
+            "time": "2015-01-28 01:03:29"
         },
         {
-            "name": "lwc/smartling-php",
-            "version": "0.0.1",
+            "name": "guzzlehttp/ringphp",
+            "version": "1.0.7",
             "source": {
                 "type": "git",
-                "url": "https://github.com/lwc/smartling-php.git",
-                "reference": "0.0.1"
+                "url": "https://github.com/guzzle/RingPHP.git",
+                "reference": "52d868f13570a9a56e5fce6614e0ec75d0f13ac2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/lwc/smartling-php/zipball/0.0.1",
-                "reference": "0.0.1",
+                "url": "https://api.github.com/repos/guzzle/RingPHP/zipball/52d868f13570a9a56e5fce6614e0ec75d0f13ac2",
+                "reference": "52d868f13570a9a56e5fce6614e0ec75d0f13ac2",
                 "shasum": ""
             },
             "require": {
-                "guzzle/guzzle": ">=3.1.1,<3.2"
+                "guzzlehttp/streams": "~3.0",
+                "php": ">=5.4.0",
+                "react/promise": "~2.0"
+            },
+            "require-dev": {
+                "ext-curl": "*",
+                "phpunit/phpunit": "~4.0"
+            },
+            "suggest": {
+                "ext-curl": "Guzzle will use specific adapters if cURL is present"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
             "autoload": {
-                "psr-0": {
-                    "Smartling": "lib"
+                "psr-4": {
+                    "GuzzleHttp\\Ring\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -126,41 +107,141 @@
             ],
             "authors": [
                 {
-                    "name": "Luke Cawood",
-                    "email": "luke.cawood@99designs.com"
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
                 }
             ],
-            "description": "PHP client for Smartling's file API",
-            "keywords": [
-                "api",
-                "i18n",
-                "smartling",
-                "translation"
+            "description": "Provides a simple API and specification that abstracts away the details of HTTP into a single PHP function.",
+            "time": "2015-03-30 01:43:20"
+        },
+        {
+            "name": "guzzlehttp/streams",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/streams.git",
+                "reference": "47aaa48e27dae43d39fc1cea0ccf0d84ac1a2ba5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/streams/zipball/47aaa48e27dae43d39fc1cea0ccf0d84ac1a2ba5",
+                "reference": "47aaa48e27dae43d39fc1cea0ccf0d84ac1a2ba5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Stream\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
             ],
-            "time": "2013-04-17 05:44:41"
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Provides a simple abstraction over streams of data",
+            "homepage": "http://guzzlephp.org/",
+            "keywords": [
+                "Guzzle",
+                "stream"
+            ],
+            "time": "2014-10-12 19:18:40"
+        },
+        {
+            "name": "react/promise",
+            "version": "v2.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/promise.git",
+                "reference": "365fcee430dfa4ace1fbc75737ca60ceea7eeeef"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/promise/zipball/365fcee430dfa4ace1fbc75737ca60ceea7eeeef",
+                "reference": "365fcee430dfa4ace1fbc75737ca60ceea7eeeef",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "React\\Promise\\": "src/"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@googlemail.com"
+                }
+            ],
+            "description": "A lightweight implementation of CommonJS Promises/A for PHP",
+            "time": "2014-12-30 13:32:42"
         },
         {
             "name": "symfony/console",
-            "version": "v2.2.1",
+            "version": "v2.6.6",
             "target-dir": "Symfony/Component/Console",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Console.git",
-                "reference": "v2.2.1"
+                "reference": "5b91dc4ed5eb08553f57f6df04c4730a73992667"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Console/zipball/v2.2.1",
-                "reference": "v2.2.1",
+                "url": "https://api.github.com/repos/symfony/Console/zipball/5b91dc4ed5eb08553f57f6df04c4730a73992667",
+                "reference": "5b91dc4ed5eb08553f57f6df04c4730a73992667",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3"
             },
+            "require-dev": {
+                "psr/log": "~1.0",
+                "symfony/event-dispatcher": "~2.1",
+                "symfony/phpunit-bridge": "~2.7",
+                "symfony/process": "~2.1"
+            },
+            "suggest": {
+                "psr/log": "For using the console logger",
+                "symfony/event-dispatcher": "",
+                "symfony/process": ""
+            },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.2-dev"
+                    "dev-master": "2.6-dev"
                 }
             },
             "autoload": {
@@ -174,87 +255,25 @@
             ],
             "authors": [
                 {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
                     "name": "Symfony Community",
                     "homepage": "http://symfony.com/contributors"
+                },
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
                 }
             ],
             "description": "Symfony Console Component",
             "homepage": "http://symfony.com",
-            "time": "2013-03-19 20:48:08"
-        },
-        {
-            "name": "symfony/event-dispatcher",
-            "version": "v2.2.1",
-            "target-dir": "Symfony/Component/EventDispatcher",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/EventDispatcher.git",
-                "reference": "v2.2.1"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/EventDispatcher/zipball/v2.2.1",
-                "reference": "v2.2.1",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.3"
-            },
-            "require-dev": {
-                "symfony/dependency-injection": ">=2.0,<3.0"
-            },
-            "suggest": {
-                "symfony/dependency-injection": "2.2.*",
-                "symfony/http-kernel": "2.2.*"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.2-dev"
-                }
-            },
-            "autoload": {
-                "psr-0": {
-                    "Symfony\\Component\\EventDispatcher\\": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "http://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony EventDispatcher Component",
-            "homepage": "http://symfony.com",
-            "time": "2013-02-11 11:26:43"
+            "time": "2015-03-30 15:54:10"
         }
     ],
-    "packages-dev": [
-
-    ],
-    "aliases": [
-
-    ],
+    "packages-dev": [],
+    "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [
-
-    ],
-    "platform": [
-
-    ],
-    "platform-dev": [
-
-    ]
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": []
 }

--- a/composer.lock
+++ b/composer.lock
@@ -1,23 +1,22 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
-        "This file is @generated automatically"
+        "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file"
     ],
-    "hash": "52a5d39f069a0bcb159a8aac3f1f5303",
+    "hash": "609f0615adc72fe0cf79905ceb3e2856",
     "packages": [
         {
             "name": "guzzle/guzzle",
             "version": "v3.1.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "7901ea7d27373d0cc85eac6f6694e4c2ced90a26"
+                "url": "https://github.com/guzzle/guzzle",
+                "reference": "v3.1.2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/7901ea7d27373d0cc85eac6f6694e4c2ced90a26",
-                "reference": "7901ea7d27373d0cc85eac6f6694e4c2ced90a26",
+                "url": "https://github.com/guzzle/guzzle/archive/v3.1.2.zip",
+                "reference": "v3.1.2",
                 "shasum": ""
             },
             "require": {
@@ -104,16 +103,16 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/lwc/smartling-php.git",
-                "reference": "06e811a9a54ff82233b2419f0316fd81d83471e7"
+                "reference": "0.0.1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/lwc/smartling-php/zipball/06e811a9a54ff82233b2419f0316fd81d83471e7",
-                "reference": "06e811a9a54ff82233b2419f0316fd81d83471e7",
+                "url": "https://api.github.com/repos/lwc/smartling-php/zipball/0.0.1",
+                "reference": "0.0.1",
                 "shasum": ""
             },
             "require": {
-                "guzzle/guzzle": "~3.1.1"
+                "guzzle/guzzle": ">=3.1.1,<3.2"
             },
             "type": "library",
             "autoload": {
@@ -147,12 +146,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Console.git",
-                "reference": "d146fc32a9cf13bc479820e515048298a34cd432"
+                "reference": "v2.2.1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Console/zipball/d146fc32a9cf13bc479820e515048298a34cd432",
-                "reference": "d146fc32a9cf13bc479820e515048298a34cd432",
+                "url": "https://api.github.com/repos/symfony/Console/zipball/v2.2.1",
+                "reference": "v2.2.1",
                 "shasum": ""
             },
             "require": {
@@ -176,9 +175,7 @@
             "authors": [
                 {
                     "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com",
-                    "homepage": "http://fabien.potencier.org",
-                    "role": "Lead Developer"
+                    "email": "fabien@symfony.com"
                 },
                 {
                     "name": "Symfony Community",
@@ -196,19 +193,19 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/EventDispatcher.git",
-                "reference": "45c43ffa186a0473c71a947981e43e025cd93c87"
+                "reference": "v2.2.1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/EventDispatcher/zipball/45c43ffa186a0473c71a947981e43e025cd93c87",
-                "reference": "45c43ffa186a0473c71a947981e43e025cd93c87",
+                "url": "https://api.github.com/repos/symfony/EventDispatcher/zipball/v2.2.1",
+                "reference": "v2.2.1",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3"
             },
             "require-dev": {
-                "symfony/dependency-injection": "~2.0"
+                "symfony/dependency-injection": ">=2.0,<3.0"
             },
             "suggest": {
                 "symfony/dependency-injection": "2.2.*",
@@ -232,9 +229,7 @@
             "authors": [
                 {
                     "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com",
-                    "homepage": "http://fabien.potencier.org",
-                    "role": "Lead Developer"
+                    "email": "fabien@symfony.com"
                 },
                 {
                     "name": "Symfony Community",
@@ -246,11 +241,20 @@
             "time": "2013-02-11 11:26:43"
         }
     ],
-    "packages-dev": [],
-    "aliases": [],
+    "packages-dev": [
+
+    ],
+    "aliases": [
+
+    ],
     "minimum-stability": "stable",
-    "stability-flags": [],
-    "prefer-stable": false,
-    "platform": [],
-    "platform-dev": []
+    "stability-flags": [
+
+    ],
+    "platform": [
+
+    ],
+    "platform-dev": [
+
+    ]
 }

--- a/lib/Phreepio/Command/DownloadCommand.php
+++ b/lib/Phreepio/Command/DownloadCommand.php
@@ -27,12 +27,8 @@ class DownloadCommand extends PhreepioCommand
         foreach ($translator->getDownloadIterator() as $i => $result)
         {
             if ($result->success) {
-                if ($result->usedCache) {
-                    $output->writeln('Found cache: <comment>'.$result->remotePath.'</comment> for locale <comment>'.$result->locale.'</comment>');
-                } else {
-                    $output->writeln('<info>Succeeded</info> to download <comment>'.$result->remotePath.'</comment> for locale <comment>'.$result->locale.'</comment>');
-                }
 
+                $output->writeln('<info>Succeeded</info> to download <comment>'.$result->remotePath.'</comment> for locale <comment>'.$result->locale.'</comment>');
                 $output->writeln('Translation saved in <comment>'.$result->localPath.'</comment>');
             }
             else {

--- a/lib/Phreepio/Command/DownloadCommand.php
+++ b/lib/Phreepio/Command/DownloadCommand.php
@@ -24,18 +24,22 @@ class DownloadCommand extends PhreepioCommand
 
         $translator = $this->getTranslator();
 
-        foreach ($translator->getDownloadIterator() as $i => $result)
+        foreach ($translator->getDownloadIterator() as $i => $resultPromise)
         {
-            if ($result->success) {
+            $resultPromise->then(function($result) use ($output) {
+                if ($result->success) {
 
-                $output->writeln('<info>Succeeded</info> to download <comment>'.$result->remotePath.'</comment> for locale <comment>'.$result->locale.'</comment>');
-                $output->writeln('Translation saved in <comment>'.$result->localPath.'</comment>');
-            }
-            else {
-                $output->writeln('<error>Failed to download "'.$result->remotePath.'" for locale "'.$result->locale.'"</error>');
-                $output->writeln('<comment>'.$result->errorMessage.'</comment>');
-            }
-            $output->writeln('');
+                    $output->writeln('<info>Succeeded</info> to download <comment>'.$result->remotePath.'</comment> for locale <comment>'.$result->locale.'</comment>');
+                    $output->writeln('Translation saved in <comment>'.$result->localPath.'</comment>');
+                }
+                else {
+                    $output->writeln('<error>Failed to download "'.$result->remotePath.'" for locale "'.$result->locale.'"</error>');
+                    $output->writeln('<comment>'.$result->errorMessage.'</comment>');
+                }
+                $output->writeln('');
+            });
         }
+
+        $this->getTranslator()->flush();
     }
 }

--- a/lib/Phreepio/Command/PhreepioCommand.php
+++ b/lib/Phreepio/Command/PhreepioCommand.php
@@ -14,6 +14,7 @@ use Phreepio\Configuration;
 class PhreepioCommand extends Command
 {
     private $phreepioConfig;
+    private $translator;
 
     protected function getPhreepioConfig()
     {
@@ -29,6 +30,10 @@ class PhreepioCommand extends Command
 
     protected function getTranslator()
     {
-        return $this->getPhreepioConfig()->getTranslator();
+        if (!$this->translator) {
+            $this->translator = $this->getPhreepioConfig()->getTranslator();
+        }
+
+        return $this->translator;
     }
 }

--- a/lib/Phreepio/Command/StatusCommand.php
+++ b/lib/Phreepio/Command/StatusCommand.php
@@ -26,15 +26,16 @@ class StatusCommand extends PhreepioCommand
 
         $translator = $this->getTranslator();
         $errors = array();
-        foreach ($translator->getStatusIterator() as $source => $result)
+        foreach ($translator->getStatusIterator() as $source => $resultPromise)
         {
-            if ($result->success) {
+            $resultPromise->then(function($result) use ($output, &$errors) {
+                if ($result->success) {
 
-                $output->writeln($this->getProgress($result->stringCount, $result->approvedStringCount, $result->completedStringCount) . ' <info>'.$result->remotePath.'</info> locale: <info>'.$result->locale.'</info>');
-            }
-            else {
-                $errors[]= $result;
-            }
+                    $output->writeln($this->getProgress($result->stringCount, $result->approvedStringCount, $result->completedStringCount) . ' <info>' . $result->remotePath . '</info> locale: <info>' . $result->locale . '</info>');
+                } else {
+                    $errors[] = $result;
+                }
+            });
         }
 
         if ($errors) {
@@ -44,6 +45,8 @@ class StatusCommand extends PhreepioCommand
                 $output->writeln('File <comment>'.$error->remotePath.'</comment> Locale <comment>'.$error->locale.'</comment>: <info>'.$error->errorMessage.'</info>');
             }
         }
+
+        $this->getTranslator()->flush();
     }
 
     private function getProgress($total, $approved, $translated)

--- a/lib/Phreepio/Command/UploadCommand.php
+++ b/lib/Phreepio/Command/UploadCommand.php
@@ -25,22 +25,25 @@ class UploadCommand extends PhreepioCommand
 
         $translator = $this->getTranslator();
 
-        foreach ($translator->getUploadIterator() as $source => $result)
+        foreach ($translator->getUploadIterator() as $source => $resultPromise)
         {
-            if ($result->success) {
+            $resultPromise->then(function($result) use ($output, $source) {
+                if ($result->success) {
 
-                $verb = "Added";
-                if ($result->overWritten) {
-                    $verb = "<comment>Overwrote remote</comment>";
+                    $verb = "Added";
+                    if ($result->overWritten) {
+                        $verb = "<comment>Overwrote remote</comment>";
+                    }
+                    $output->writeln("$verb: <info>$source</info>");
+                    $output->writeln("String Count: <info>{$result->stringCount}</info>");
+                } else {
+                    $output->writeln('<error>Failed to upload "' . $source . '"</error>');
+                    $output->writeln('<comment>' . $result->errorMessage . '</comment>');
                 }
-                $output->writeln("$verb: <info>$source</info>");
-                $output->writeln("String Count: <info>{$result->stringCount}</info>");
-            }
-            else {
-                $output->writeln('<error>Failed to upload "'.$source.'"</error>');
-                $output->writeln('<comment>'.$result->errorMessage.'</comment>');
-            }
-            $output->writeln('');
+                $output->writeln('');
+            });
         }
+
+        $translator->flush();
     }
 }

--- a/lib/Phreepio/Smartling/Client.php
+++ b/lib/Phreepio/Smartling/Client.php
@@ -1,0 +1,189 @@
+<?php
+
+namespace Phreepio\Smartling;
+
+use GuzzleHttp\Client as GuzzleClient;
+use GuzzleHttp\Event\CompleteEvent;
+use GuzzleHttp\Event\ErrorEvent;
+use GuzzleHttp\Message\Request;
+use GuzzleHttp\Pool;
+use GuzzleHttp\Post\PostBody;
+use GuzzleHttp\Post\PostFile;
+use React\Promise\Deferred;
+
+class Client
+{
+    const BASEURL_PROD = 'https://api.smartling.com/v1/';
+    const BASEURL_SANDBOX = 'https://sandbox-api.smartling.com/v1/';
+
+    const TYPE_ANDROID = 'android';
+    const TYPE_IOS = 'ios';
+    const TYPE_GETTEXT = 'gettext';
+    const TYPE_HTML = 'html';
+    const TYPE_JAVA = 'javaProperties';
+    const TYPE_XLIFF = 'xliff';
+    const TYPE_XML = 'xml';
+    const TYPE_JSON = 'json';
+    const TYPE_YAML = 'yaml';
+
+    private $client;
+    private $apiKey;
+    private $projectId;
+    private $useSandbox;
+    private $requests = [];
+
+    public function __construct($apiKey, $projectId, $useSandbox=false)
+    {
+        $this->client = new GuzzleClient([
+            'base_url' => $useSandbox ? self::BASEURL_SANDBOX : self::BASEURL_PROD
+        ]);
+
+        $this->apiKey = $apiKey;
+        $this->projectId = $projectId;
+        $this->useSandbox = $useSandbox;
+    }
+
+    public function upload($source, $target, $type, $approved=true, $options=null, $callbackUrl=null)
+    {
+
+        $body = new PostBody();
+
+        foreach ($options as $k => $v) {
+            $body->setField("smartling.$k", $v);
+        }
+
+        $body->setField('apiKey', $this->apiKey);
+        $body->setField('projectId', $this->projectId);
+        $body->setField('fileType', $type);
+        $body->setField('fileUri', $target);
+        $body->setField('approved', $approved ? 'true' : 'false');
+
+        $body->addFile(new PostFile('file', file_get_contents($source)));
+
+        $request = $this->client->createRequest('POST', 'file/upload', [
+            'body' => $body
+        ]);
+
+        return $this->queueRequest($request);
+    }
+
+    public function get($source, $target, $locale=null, $retrievalType=null)
+    {
+        $args = array(
+            'apiKey' => $this->apiKey,
+            'projectId' => $this->projectId,
+            'fileUri' => $source
+        );
+        if (isset($locale)) {
+            $args['locale'] = $locale;
+        }
+        if (isset($retrievalType)) {
+            $args['retrievalType'] = $retrievalType;
+        }
+
+        $request = $this->client->createRequest('GET', 'file/get');
+        $request->getQuery()->merge($args);
+
+        $ret = $this->queueRequest($request, true)->then(function(CompleteEvent $e) use ($target) {
+            file_put_contents($target, $e->getResponse()->getBody()->getContents());
+        });
+
+        return $ret;
+    }
+
+    public function files($searchTerms=null)
+    {
+        if (!is_array($searchTerms)) {
+            $searchTerms = array();
+        }
+        $request = $this->client->createRequest('GET', 'file/list');
+
+        $request->getQuery()->merge(array_merge($searchTerms, array(
+            'apiKey' => $this->apiKey,
+            'projectId' => $this->projectId,
+        )));
+
+        return $this->queueRequest($request);
+    }
+
+    public function status($fileUri, $locale)
+    {
+        $args = array(
+            'apiKey' => $this->apiKey,
+            'projectId' => $this->projectId,
+            'fileUri' => $fileUri,
+            'locale' => $locale
+        );
+
+        $request = $this->client->createRequest('GET', 'file/status');
+        $request->getQuery()->merge($args);
+        return $this->queueRequest($request);
+    }
+
+    public function rename($fileUri, $newFileUri)
+    {
+        $body = new PostBody();
+        $body->setField('apiKey', $this->apiKey);
+        $body->setField('projectId', $this->projectId);
+        $body->setField('fileUri', $fileUri);
+        $body->setField('newFileUri', $newFileUri);
+
+        $request = $this->client->createRequest('POST', 'file/rename');
+        $request->setBody($body);
+        return $this->queueRequest($request);
+    }
+
+    public function delete($fileUri)
+    {
+         $args = array(
+            'apiKey' => $this->apiKey,
+            'projectId' => $this->projectId,
+            'fileUri' => $fileUri,
+        );
+
+        $request = $this->client->createRequest('DELETE', 'file/delete');
+        $request->getQuery()->merge($args);
+        return $this->queueRequest($request);
+    }
+
+    /**
+     * @param Request $request
+     * @param bool $attachment
+     *
+     * @return \React\Promise\Promise that yields the response data, or a CompleteEvent if attachment = true
+     */
+    protected function queueRequest(Request $request, $attachment = false)
+    {
+        $deferred = new Deferred();
+
+        $this->requests[] = $request;
+
+        $request->getEmitter()->on('complete', function(CompleteEvent $e) use ($attachment, $deferred) {
+            if (!$attachment) {
+                $outer = $e->getResponse()->json();
+                $deferred->resolve($outer['response']['data']);
+
+            } else {
+                $deferred->resolve($e);
+            }
+        });
+
+        $request->getEmitter()->on('error', function(ErrorEvent $e) use ($deferred) {
+            $deferred->reject($e->getException()->getMessage() . "\nBody: " . $e->getResponse()->getBody()->getContents());
+        });
+
+        return $deferred->promise();
+    }
+
+    /**
+     * Sends all of the requests concurrently and fulfills the promises
+     */
+    public function sendAll()
+    {
+        $pool = new Pool($this->client, $this->requests, [
+            'pool_size' => 20,
+        ]);
+        $pool->wait();
+        $this->requests = [];
+    }
+}

--- a/lib/Phreepio/Translator/Adapter.php
+++ b/lib/Phreepio/Translator/Adapter.php
@@ -9,10 +9,4 @@ interface Adapter
     public function upload($localPath, $remotePath, $type);
 
     public function status($remotePath, $locale);
-
-    public function enableCache();
-
-    public function cacheVersion();
-
-    public function cacheMaxAge();
 }

--- a/lib/Phreepio/Translator/Adapter.php
+++ b/lib/Phreepio/Translator/Adapter.php
@@ -2,11 +2,27 @@
 
 namespace Phreepio\Translator;
 
+use React\Promise\PromiseInterface;
+
 interface Adapter
 {
+    /**
+     * @return PromiseInterface
+     */
     public function download($remotePath, $localPath, $locale);
 
+    /**
+     * @return PromiseInterface
+     */
     public function upload($localPath, $remotePath, $type);
 
+    /**
+     * @return PromiseInterface
+     */
     public function status($remotePath, $locale);
+
+    /**
+     * Called before exit to ensure any pending requests are sent.
+     */
+    public function flush();
 }

--- a/lib/Phreepio/Translator/DownloadIterator.php
+++ b/lib/Phreepio/Translator/DownloadIterator.php
@@ -6,16 +6,14 @@ class DownloadIterator implements \Iterator
 {
     private $translator;
     private $remotePaths;
-    private $skeletonPaths;
     private $locales;
     private $destinationPattern;
 
-    public function __construct($translator, $remotePaths, $skeletonPaths, $locales, $destinationPattern)
+    public function __construct($translator, $remotePaths, $locales, $destinationPattern)
     {
         $this->translator = $translator;
         $this->remotePaths = new \ArrayIterator($remotePaths);
         $this->locales = new \ArrayIterator($locales);
-        $this->skeletonPaths = new \ArrayIterator($skeletonPaths);
         $this->destinationPattern = $destinationPattern;
     }
 
@@ -24,30 +22,25 @@ class DownloadIterator implements \Iterator
         $remotePath = $this->remotePaths->current();
         $locale = $this->locales->current();
         $localPath = $this->getLocalPath($remotePath, $locale);
-
-        $skeletonPath = $this->skeletonPaths->current();
-
-        if ($this->translator->enableCache() && file_exists($skeletonPath)) {
-            $cachePath = $this->getCachePath($skeletonPath, $localPath);
-            if (!file_exists($cachePath) || $this->hasCacheExpired($cachePath)) {
-                $this->makeCacheDir($cachePath);
-                $result = $this->downloadTranslation($remotePath, $cachePath, $locale);
-            } else {
-                $result = (object)array(
-                    'success' => true,
-                    'usedCache' => true,
-                    'localPath' => $localPath,
-                    'locale' => $locale,
-                    'remotePath' => $remotePath
-                );
-            }
-
-            copy($cachePath, $localPath);
-
-            return $result;
-        } else {
-            return $this->downloadTranslation($remotePath, $localPath, $locale);
+        try {
+            $this->translator->download($remotePath, $localPath, $locale);
         }
+        catch (\Exception $e) {
+            return (object)array(
+                'success' => false,
+                'errorMessage' => $e->getMessage(),
+                'errorType' => get_class($e),
+                'localPath' => $localPath,
+                'locale' => $locale,
+                'remotePath' => $remotePath                
+            );
+        }
+        return (object)array(
+            'success' => true,
+            'localPath' => $localPath,
+            'locale' => $locale,
+            'remotePath' => $remotePath
+        );
     }
 
     public function key()
@@ -64,7 +57,6 @@ class DownloadIterator implements \Iterator
         $this->locales->rewind();
 
         $this->remotePaths->next();
-        $this->skeletonPaths->next();
     }
 
     public function rewind()
@@ -72,7 +64,6 @@ class DownloadIterator implements \Iterator
         $this->index = 0;
         $this->locales->rewind();
         $this->remotePaths->rewind();
-        $this->skeletonPaths->rewind();
     }
 
     public function valid()
@@ -92,89 +83,6 @@ class DownloadIterator implements \Iterator
             array_keys($targetParts),
             array_values($targetParts),
             $this->destinationPattern
-        );
-    }
-
-    private function downloadTranslation($remotePath, $localPath, $locale) {
-        try {
-            $tmpPath = $this->getTmpPath($localPath);
-            $this->translator->download($remotePath, $tmpPath, $locale);
-        }
-        catch (\Exception $e) {
-            return (object)array(
-                'success' => false,
-                'errorMessage' => $e->getMessage(),
-                'errorType' => get_class($e),
-                'localPath' => $localPath,
-                'locale' => $locale,
-                'remotePath' => $remotePath
-            );
-        }
-
-        rename($tmpPath, $localPath);
-
-        return (object)array(
-            'success' => true,
-            'usedCache' => false,
-            'localPath' => $localPath,
-            'locale' => $locale,
-            'remotePath' => $remotePath
-        );
-    }
-
-    private function makeCacheDir($cachePath)
-    {
-        $cacheDir = dirname($cachePath);
-        if (!file_exists($cacheDir)) {
-            mkdir($cacheDir, 0777, true);
-        }
-    }
-
-    /**
-     * Get the cache path of the translation file
-     * @param  string $skeletonPath Smartling's skeleton file path
-     * @param  string $localPath    Local translation file path
-     * @return string               Path to the cached translation
-     */
-    private function getCachePath($skeletonPath, $localPath)
-    {
-        $pathInfo = pathInfo($localPath);
-        $hash = md5_file($skeletonPath);
-
-        return sprintf(
-            "%s/.cache/%s.%s.%s/%s",
-            $pathInfo['dirname'],
-            pathinfo($skeletonPath, PATHINFO_FILENAME),
-            $hash,
-            $this->translator->cacheVersion(),
-            $pathInfo['basename']
-        );
-    }
-
-    /**
-     * Checks the file path against the specified cache age
-     * @param  string  $filepath translation
-     * @return boolean
-     */
-    private function hasCacheExpired($filepath)
-    {
-        return (filemtime($filepath) + $this->translator->cacheMaxAge()) < time();
-    }
-
-    /**
-     * Get the temporary path for downloading.
-     * After download is complete the temp path will get rename to the permanent path.
-     * @param  string $filePath
-     * @return string
-     */
-    private function getTmpPath($filePath)
-    {
-        $filename = pathinfo($filePath, PATHINFO_FILENAME);
-
-        return str_replace(
-            $filename,
-            'tmp-' . $filename,
-            $filePath
         );
     }
 }

--- a/lib/Phreepio/Translator/SmartlingTranslator.php
+++ b/lib/Phreepio/Translator/SmartlingTranslator.php
@@ -9,19 +9,14 @@ class SmartlingTranslator implements Adapter
     private $client;
     private $autoApprove;
     private $placeholderFormat;
-    private $enableCache;
-    private $cacheVersion;
-    private $cacheMaxAge;
 
     public function __construct($config)
     {
         $useSandbox = isset($config->useSandbox) ? $config->useSandbox : true;
         $this->placeholderFormat = isset($config->placeholderFormat) ? $config->placeholderFormat : null;
+
         $this->autoApprove = isset($config->autoApprove) ? $config->autoApprove : false ;
         $this->client = new Client($config->apiKey, $config->projectId, $useSandbox);
-        $this->enableCache = isset($config->enableCache) ? $config->enableCache : false;
-        $this->cacheVersion = isset($config->cacheVersion) ? $config->cacheVersion : "v1.0";
-        $this->cacheMaxAge = isset($config->cacheMaxAge) ? $config->cacheMaxAge : 3600; // Default to 1 hour
     }
 
     public function download($remotePath, $localPath, $locale)
@@ -41,21 +36,6 @@ class SmartlingTranslator implements Adapter
     public function status($remotePath, $locale)
     {
         return (object)$this->client->status($remotePath, $this->normaliseLocale($locale));
-    }
-
-    public function enableCache()
-    {
-        return $this->enableCache;
-    }
-
-    public function cacheVersion()
-    {
-        return $this->cacheVersion;
-    }
-
-    public function cacheMaxAge()
-    {
-        return $this->cacheMaxAge;
     }
 
     /**

--- a/lib/Phreepio/Translator/SmartlingTranslator.php
+++ b/lib/Phreepio/Translator/SmartlingTranslator.php
@@ -2,7 +2,7 @@
 
 namespace Phreepio\Translator;
 
-use Smartling\Client;
+use Phreepio\Smartling\Client;
 
 class SmartlingTranslator implements Adapter
 {
@@ -21,7 +21,7 @@ class SmartlingTranslator implements Adapter
 
     public function download($remotePath, $localPath, $locale)
     {
-        $this->client->get($remotePath, $localPath, $this->normaliseLocale($locale));
+        return $this->client->get($remotePath, $localPath, $this->normaliseLocale($locale));
     }
 
     public function upload($localPath, $remotePath, $type)
@@ -30,12 +30,12 @@ class SmartlingTranslator implements Adapter
         if ($this->placeholderFormat) {
             $options['placeholder_format_custom'] = $this->placeholderFormat;
         }
-        return (object)$this->client->upload($localPath, $remotePath, $type, $this->autoApprove, $options);
+        return $this->client->upload($localPath, $remotePath, $type, $this->autoApprove, $options);
     }
 
     public function status($remotePath, $locale)
     {
-        return (object)$this->client->status($remotePath, $this->normaliseLocale($locale));
+        return $this->client->status($remotePath, $this->normaliseLocale($locale));
     }
 
     /**
@@ -47,5 +47,10 @@ class SmartlingTranslator implements Adapter
     private function normaliseLocale($locale)
     {
         return str_replace('_', '-', $locale);
+    }
+
+    public function flush()
+    {
+        $this->client->sendAll();
     }
 }

--- a/lib/Phreepio/Translator/Translator.php
+++ b/lib/Phreepio/Translator/Translator.php
@@ -2,6 +2,8 @@
 
 namespace Phreepio\Translator;
 
+use React\Promise\PromiseInterface;
+
 class Translator
 {
     private $adapter;
@@ -13,11 +15,17 @@ class Translator
         $this->config = $config;
     }
 
+    /**
+     * @return UploadIterator|PromiseInterface[]
+     */
     public function getUploadIterator()
     {
         return new UploadIterator($this->adapter, $this->config->sources);
     }
 
+    /**
+     * @return DownloadIterator|PromiseInterface[]
+     */
     public function getDownloadIterator()
     {
         $remotePaths = array();
@@ -31,6 +39,9 @@ class Translator
         return new DownloadIterator($this->adapter, $remotePaths, $locales, $destinationPattern);
     }
 
+    /**
+     * @return StatusIterator|PromiseInterface[]
+     */
     public function getStatusIterator()
     {
         $remotePaths = array();
@@ -40,5 +51,10 @@ class Translator
 
         $locales = $this->config->target->locales;
         return new StatusIterator($this->adapter, $remotePaths, $locales);        
+    }
+
+    public function flush()
+    {
+        $this->adapter->flush();
     }
 }

--- a/lib/Phreepio/Translator/Translator.php
+++ b/lib/Phreepio/Translator/Translator.php
@@ -20,18 +20,15 @@ class Translator
 
     public function getDownloadIterator()
     {
-        $skeletonPaths = array();
         $remotePaths = array();
-
-        foreach ($this->config->sources as $skeletonPath => $source) {
+        foreach ($this->config->sources as $source) {
             $remotePaths[] = $source->target;
-            $skeletonPaths[] = $skeletonPath;
         }
 
         $locales = $this->config->target->locales;
         $destinationPattern = $this->config->target->destination;
 
-        return new DownloadIterator($this->adapter, $remotePaths, $skeletonPaths, $locales, $destinationPattern);
+        return new DownloadIterator($this->adapter, $remotePaths, $locales, $destinationPattern);
     }
 
     public function getStatusIterator()
@@ -42,6 +39,6 @@ class Translator
         }
 
         $locales = $this->config->target->locales;
-        return new StatusIterator($this->adapter, $remotePaths, $locales);
+        return new StatusIterator($this->adapter, $remotePaths, $locales);        
     }
 }


### PR DESCRIPTION
This implements concurrent downloads using promises and guzzle pools.

It requires bumping the guzzle version to 5 to get access to the new Pool features. This is going to be a backwards incompatible change.

The speedup is probably worth it though. With the 80 files to download the time goes from ~5.5 minutes to ~25 seconds.